### PR TITLE
Fix `make minify`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev:
 
 .PHONY: minify
 minify:
-	npx lightningcss --minify oatcake.css --output-file oatcake.min.css
+	npx lightningcss-cli --minify oatcake.css --output-file oatcake.min.css
 
 .PHONY: format
 format:


### PR DESCRIPTION
It looks like the Lightning CSS CLI moved into a separate
`lightningcss-cli` package?
