### PR TITLE
Attempt to remove Makefile from GitHub releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Makefile: export-ignore


### PR DESCRIPTION
I'm hoping this might also remove the file from jsDelivr, but I don't
expect that it will.
