### PR TITLE
Remove more unnecessary files from GitHub Releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,11 @@
+.gitattributes export-ignore
+.github/ export-ignore
+.gitignore export-ignore
+.htmlvalidate.json export-ignore
+.prettierignore export-ignore
 Makefile export-ignore
+README.md export-ignore
+oatcake.css export-ignore
+package-lock.json export-ignore
+package.json export-ignore
+site/ export-ignore


### PR DESCRIPTION
The release archive files just need to contain the minified CSS file and
the LICENSE file, nothing more.

This doesn't seem to remove the files from jsDelivr unfortunately.
