### PR TITLE
Remove npm token from GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,3 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm --no-git-tag-version version ${{ github.event.release.tag_name }}
       - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I don't think this is needed when using trusted publishing.
