### PR TITLE
Remove the provenance flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,4 +15,4 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm --no-git-tag-version version ${{ github.event.release.tag_name }}
-      - run: npm publish --provenance
+      - run: npm publish


### PR DESCRIPTION
It's not needed with trusted publishing.
