### PR TITLE
Remove README and LICENSE from package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,5 @@
   },
   "files": [
     "oatcake.min.css",
-    "README.md",
-    "LICENSE"
   ]
 }


### PR DESCRIPTION
These files are always included.
