### PR TITLE
Get npm package metadata from GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,5 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Update npm
         run: npm install -g npm@latest
-      - run: npm --no-git-tag-version version ${{ github.event.release.tag_name }}
-      - run: npm publish --tag latest
+      - name: Publish package
+        run: bin/release.sh ${{ github.event.release.tag_name }}

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+temp_file=$(mktemp)
+trap 'rm -f "$temp_file"' EXIT
+
+gh repo view --json name,description,licenseInfo,homepageUrl,url,repositoryTopics > "$temp_file"
+
+npm pkg set \
+  name="$(jq -r .name < "$temp_file")" \
+  description="$(jq -r .description < "$temp_file")" \
+  license="$(jq -r '.licenseInfo.key | ascii_upcase' < "$temp_file")" \
+  homepage="$(jq -r .homepageUrl < "$temp_file")" \
+  bugs.url="$(jq -r .url < "$temp_file")/issues" \
+  repository.type="git" \
+  repository.url="$(jq -r .url < "$temp_file")"
+
+npm pkg set --json keywords="$(jq -c '.repositoryTopics | map(.name)' < "$temp_file")"
+
+npm version --no-git-tag-version "$1"
+
+npm publish --tag latest

--- a/package.json
+++ b/package.json
@@ -1,18 +1,9 @@
 {
-  "name": "oatcake",
   "author": "Sean Hammond (https://seanh.cc)",
-  "description": "A drop-in CSS stylesheet that makes pages attractive and readable.",
-  "license": "MIT",
-  "homepage": "https://www.seanh.cc/oatcake/",
-  "bugs": "https://github.com/seanh/oatcake/issues",
   "devDependencies": {
     "html-validate": "^10.2.1",
     "lightningcss-cli": "^1.30.2",
     "prettier": "^3.6.2"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/seanh/oatcake"
   },
   "files": [
     "oatcake.min.css"


### PR DESCRIPTION
Avoid duplicating various metadata about the project in the
`package.json` file. Instead have the `release.yml` file get the
metadata from `gh repo view` instead.
