### PR TITLE
Preload banner images

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Oatcake: Plain Web Typography</title>
+    <link rel="preload" as="image" href="/media/shovel.svg" />
+    <link rel="preload" as="image" href="/media/oatcakes.svg" />
+    <link rel="preload" as="image" href="/media/oatmilk.svg" />
     <link rel="stylesheet" href="oatcake.min.css" />
     <link rel="stylesheet" href="gh-fork-ribbon.css" />
     <link rel="stylesheet" href="lines/lines.css" />


### PR DESCRIPTION
This wastes bandwidth loading all three SVGs when only one will be
used, but I think it might cause the one image that is chosen to render
quicker. Currently there's a noticeable short delay after the page
renders before the banner image renders.
