### PR TITLE
Remove the randomization of the banner image

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,9 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Oatcake: Plain Web Typography</title>
-    <link rel="preload" as="image" href="/media/shovel.svg" />
     <link rel="preload" as="image" href="/media/oatcakes.svg" />
-    <link rel="preload" as="image" href="/media/oatmilk.svg" />
     <link rel="stylesheet" href="oatcake.min.css" />
     <link rel="stylesheet" href="gh-fork-ribbon.css" />
     <link rel="stylesheet" href="lines/lines.css" />
@@ -137,31 +135,12 @@
     <main
       style="max-width: 40em; margin: 0 auto 0 auto; padding: 0 0.5em 0 0.5em"
     >
-      <script>
-        (function () {
-          const images = [
-            { filename: "shovel.svg", height: 240 },
-            { filename: "oatcakes.svg", height: 240 },
-            { filename: "oatmilk.svg", height: 240 },
-          ];
-          const chosenImage = images[Math.floor(Math.random() * images.length)];
-          const img = document.createElement("img");
-          img.src = `media/${chosenImage.filename}`;
-          img.height = chosenImage.height;
-          img.alt = "Oatcake banner image";
-          img.className = "noresize banner";
-          document.currentScript.parentNode.appendChild(img);
-        })();
-      </script>
-
-      <noscript>
-        <img
-          alt="Oatcake banner image"
-          src="media/shovel.svg"
-          height="240"
-          class="noresize banner"
-        />
-      </noscript>
+      <img
+        alt="Oatcake banner image"
+        src="media/oatcakes.svg"
+        height="240"
+        class="noresize banner"
+      />
 
       <hgroup>
         <h1 class="noanchor">Oatcake: Plain Web Typography</h1>


### PR DESCRIPTION
This is causing a noticeable delay between the rest of the page
rendering and then the banner image appearing, even with prefetching.
Just use the `oatcakes.svg` image (which I think is my favourite one)
all the time.

I'm keeping the other two images in the git repo in case I want them,
but they're unused.
