### PR TITLE
Watch for file changes with `entr` and `honcho`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ help:
 	@echo "make help"
 	@echo "    Show this help message."
 
-.PHONY: dev
-dev:
-	python3 -m http.server --directory site 8001
-
 .PHONY: minify
 minify:
-	npx lightningcss-cli --minify oatcake.css --output-file oatcake.min.css
+	bin/minify.sh
+
+.PHONY: dev
+dev:
+	honcho start
 
 .PHONY: format
 format:

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+watch: bin/watch.sh
+serve: bin/serve.sh

--- a/bin/minify.sh
+++ b/bin/minify.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+npx lightningcss-cli --minify oatcake.css --output-file oatcake.min.css

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+python3 -m http.server --directory site 8001

--- a/bin/watch.sh
+++ b/bin/watch.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+git ls-files -cdmo --exclude-standard | grep -v oatcake.min.css |  entr -n "${SCRIPT_DIR}/minify.sh"


### PR DESCRIPTION
This changes `make dev` to run `honcho start` which runs two processes (read from the new `Procfile`):

1. `bin/watch.sh` uses `entr` to watch for file changes and re-run `bin/minify.sh`.

   This means that `oatcake.min.css` is automatically updated when you edit `oatcake.css`.

2. `bin/serve.sh`: this runs the Python HTTP server which does not need to be restarted when files change.