### PR TITLE
Style subheadings only with `<h1>` or `<h2>`

### DIFF
--- a/oatcake.css
+++ b/oatcake.css
@@ -507,15 +507,15 @@
 
   /* Subheadings. */
   @layer elements {
-    hgroup p {
+    hgroup:has(h1, h2) p {
       font-size: 19px; /* The same size as an <h2> heading, so subheadings can be used with <h1>'s or <h2>'s. */
     }
 
-    hgroup p :is(code, samp) {
+    hgroup:has(h1, h2) p :is(code, samp) {
       font-size: 0.8em;
     }
 
-    hgroup p kbd {
+    hgroup:has(h1, h2) p kbd {
       font-size: 0.75em;
       padding-bottom: 1px;
       padding-top: 1px;

--- a/site/index.html
+++ b/site/index.html
@@ -2263,6 +2263,22 @@ disagree with this mission.&lt;/p&gt;</code></pre>
         </p>
       </div>
 
+      <p>
+        Subheadings only work with <code>&lt;h1&gt;</code> and
+        <code>&lt;h2&gt;</code> headings. If you put a <code>&lt;p&gt;</code> in
+        an <code>&lt;hgroup&gt;</code> with an
+        <code>&lt;h3&gt;</code>&ndash;<code>&lt;h6&gt;</code> heading it'll just
+        be styled like a normal paragraph, making the
+        <code>&lt;hgroup&gt;</code> semantic only:
+      </p>
+
+      <div class="example">
+        <hgroup>
+          <h3>Dr. Strangelove</h3>
+          <p>Or: How I Learned to Stop Worrying and Love the Bomb</p>
+        </hgroup>
+      </div>
+
       <details>
         <summary>
           <b>Details:</b> <code>&lt;hgroup&gt;</code> and subheadings


### PR DESCRIPTION
Style a `<p>` as a subheading only if it shares an `<hgroup>` with an
`<h1>` or an `<h2>` and not, for example, if the `<hgroup>` contains an
`<h3`> instead.

Only `<h1>`'s and `<h2>`'s are actually bigger than the subheading style,
so the style only makes sense with those.
