### PR TITLE
Remove badge links from index.html

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -139,39 +139,6 @@
         class="noresize banner"
       />
 
-      <div
-        style="
-          text-align: center;
-          display: flex;
-          flex-wrap: wrap;
-          justify-content: center;
-          gap: 4.5px;
-          height: var(--ok-line-height);
-        "
-      >
-        <a href="https://github.com/seanh/oatcake"
-          ><img
-            class="noresize"
-            style="border: none; margin: 0"
-            alt="GitHub Repo"
-            src="https://img.shields.io/badge/GitHub-seanh%2Foatcake-%231f2328?link=https%3A%2F%2Fgithub.com%2Fseanh%2Foatcake"
-        /></a>
-        <a href="https://www.npmjs.com/package/oatcake"
-          ><img
-            class="noresize"
-            style="border: none; margin: 0"
-            alt="NPM Version"
-            src="https://img.shields.io/npm/v/oatcake"
-        /></a>
-        <a href="https://www.jsdelivr.com/package/npm/oatcake"
-          ><img
-            class="noresize"
-            style="border: none; margin: 0"
-            alt="jsDelivr hits"
-            src="https://data.jsdelivr.com/v1/package/npm/oatcake/badge"
-        /></a>
-      </div>
-
       <hgroup>
         <h1 class="noanchor">Oatcake: Plain Web Typography</h1>
         <p>


### PR DESCRIPTION
Removed GitHub, NPM, and jsDelivr badge links from the index page. I don't think these are adding much, preferred it without them.