### PR TITLE
Use a lighter font-weight for subheadings

### DIFF
--- a/oatcake.css
+++ b/oatcake.css
@@ -506,6 +506,10 @@
       font-size: 19px; /* The same size as an <h2> heading, so subheadings can be used with <h1>'s or <h2>'s. */
     }
 
+    hgroup:has(h1, h2, h3, h4, h5, h6) p {
+      font-weight: 300; /* Use a lighter font-weight for subheadings. I think this looks nice and it adds a little more visual distinction between subheadings and headings or normal text, which I think is needed. This also allows subheadings to work with h3-headings: in this case the lighter font-weight is the only thing that distinguishes the subheading from normal text. */
+    }
+
     hgroup:has(h1, h2) p :is(code, samp) {
       font-size: 0.8em;
     }
@@ -516,7 +520,7 @@
       padding-top: 1px;
     }
 
-    hgroup p ~ :is(h1, h2) {
+    hgroup p ~ :is(h1, h2, h3, h4, h5, h6) {
       padding-top: 0;
     }
   }

--- a/site/index.html
+++ b/site/index.html
@@ -2202,15 +2202,17 @@ disagree with this mission.&lt;/p&gt;</code></pre>
       <h2 id="hgroup">Subheadings</h2>
 
       <p>
-        You can add a subheading to an <code>&lt;h1&gt;</code> or
-        <code>&lt;h2&gt;</code> heading by wrapping the
-        <code>&lt;h1&gt;</code> or <code>&lt;h2&gt;</code> in an
+        You can add a subheading to an <code>&lt;h1&gt;</code>&ndash;<code
+          >&lt;h6&gt;</code
+        >
+        heading by wrapping the
+        <code>&lt;h1&gt;</code>&ndash;<code>&lt;h6&gt;</code> in an
         <code>&lt;hgroup&gt;</code> along with the subheading in a
         <code>&lt;p&gt;</code>. Oatcake will style the <code>&lt;p&gt;</code> as
         a subheading&mdash;with larger text but not quite as big and bold as the
-        <code>&lt;h1&gt;</code> or <code>&lt;h2&gt;</code> heading itself. This
-        example from MDN uses a <code>&lt;p&gt;</code> to give an alternative
-        title:
+        <code>&lt;h1&gt;</code>&ndash;<code>&lt;h6&gt;</code> heading itself.
+        This example from MDN uses a <code>&lt;p&gt;</code> to give an
+        alternative title:
       </p>
 
       <pre><code>&lt;hgroup&gt;
@@ -2262,12 +2264,9 @@ disagree with this mission.&lt;/p&gt;</code></pre>
       </div>
 
       <p>
-        Subheadings only work with <code>&lt;h1&gt;</code> and
-        <code>&lt;h2&gt;</code> headings. If you put a <code>&lt;p&gt;</code> in
-        an <code>&lt;hgroup&gt;</code> with an
-        <code>&lt;h3&gt;</code>&ndash;<code>&lt;h6&gt;</code> heading it'll just
-        be styled like a normal paragraph, making the
-        <code>&lt;hgroup&gt;</code> semantic only:
+        Subheadings for <code>&lt;h3&gt;</code>&ndash;<code>&lt;h6&gt;</code>
+        headings have the same font-size as normal text but are visually
+        differentiated by their lighter font weight:
       </p>
 
       <div class="example">


### PR DESCRIPTION
I think this looks nicer.

It also makes subheadings a little bit more visually distinct from
normal text, which I think was necessary.

It also allows subheadings to work with `<h3>`-`<h6>` headings: the
lighter font-weight is the only thing that distinguishes the subheading
from normal text.
