### PR TITLE
Add at least basic support for HTML tables

### DIFF
--- a/oatcake.css
+++ b/oatcake.css
@@ -153,6 +153,7 @@
 
     aside,
     blockquote,
+    caption,
     details,
     dl,
     figcaption,
@@ -181,11 +182,12 @@
 
     /* Some elements need a bit more breathing space above and below or they feel cramped. */
     audio,
+    figure,
     iframe,
     img,
     svg,
-    video,
-    figure {
+    table,
+    video {
       margin-bottom: calc(var(--ok-line-height) * 2);
       margin-top: calc(var(--ok-line-height) * 2);
     }
@@ -780,6 +782,40 @@
       border: 1px solid var(--ok-color-border);
       padding: var(--ok-line-height) calc(0.5 * var(--ok-line-height) - 1px)
         calc(var(--ok-line-height) - 2px);
+    }
+  }
+
+  /* Tables. */
+  @layer elements {
+    table {
+      border-collapse: collapse;
+      width: 100%;
+    }
+
+    td,
+    th {
+      line-height: var(--ok-line-height);
+      padding-bottom: calc(0.5 * var(--ok-line-height));
+      padding-top: calc(0.5 * var(--ok-line-height));
+    }
+
+    :is(td, th):not(:first-child) {
+      padding-left: var(--ok-line-height);
+    }
+
+    :is(tbody, tfoot) :is(td, th) {
+      border-top: 1px solid var(--ok-color-border);
+      padding-top: calc(0.5 * var(--ok-line-height) - 1px);
+    }
+
+    th {
+      font-weight: bold;
+      text-align: left;
+    }
+
+    caption {
+      color: var(--ok-color-muted-fg);
+      text-align: center;
     }
   }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -2120,9 +2120,12 @@ disagree with this mission.&lt;/p&gt;</code></pre>
         <p>
           <code>&lt;code&gt;</code> and <code>&lt;samp&gt;</code> elements in
           headings get a monospaced font but this can be quite subtle so Oatcake
-          also surrounds the code in backticks. Oatcake also prevents
-          line-wrapping within a <code>&lt;code&gt;</code> or
-          <code>&lt;samp&gt;</code> in a heading.
+          also surrounds the code in backticks (thanks to
+          <a href="https://tailwindcss-typography.vercel.app/"
+            >Tailwind CSS Typography</a
+          >
+          for the idea). Oatcake also prevents line-wrapping within a
+          <code>&lt;code&gt;</code> or <code>&lt;samp&gt;</code> in a heading.
         </p>
 
         <div class="example">
@@ -4236,9 +4239,58 @@ int main()
       <h2 id="table">Tables</h2>
 
       <p>
-        <b>Todo!</b> Style HTML tables:
-        <a href="https://github.com/seanh/oatcake/issues/21">#21</a>
+        Tables get a pared-down look and the same colors and vertical rhythm as
+        Oatcake uses for other elements. The design is blatantly appropriated
+        from the tables in
+        <a href="https://tailwindcss-typography.vercel.app/"
+          >Tailwind CSS Typography</a
+        >, with added support for the <code>&lt;caption&gt;</code> element for
+        table captions:
       </p>
+
+      <table>
+        <caption>
+          <b>Table 1:</b>
+          an example table lifted from
+          <a href="https://tailwindcss-typography.vercel.app/"
+            >Tailwind CSS Typography</a
+          >, as styled by Oatcake.
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">Wrestler</th>
+            <th scope="col">Origin</th>
+            <th scope="col">Finisher</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Bret "The Hitman" Hart</td>
+            <td>Calgary, AB</td>
+            <td>Sharpshooter</td>
+          </tr>
+          <tr>
+            <td>Stone Cold Steve Austin</td>
+            <td>Austin, TX</td>
+            <td>Stone Cold Stunner</td>
+          </tr>
+          <tr>
+            <td>Randy Savage</td>
+            <td>Sarasota, FL</td>
+            <td>Elbow Drop</td>
+          </tr>
+          <tr>
+            <td>Vader</td>
+            <td>Boulder, CO</td>
+            <td>Vader Bomb</td>
+          </tr>
+          <tr>
+            <td>Razor Ramon</td>
+            <td>Chuluota, FL</td>
+            <td>Razor's Edge</td>
+          </tr>
+        </tbody>
+      </table>
 
       <h2 id="form">Forms</h2>
 


### PR DESCRIPTION
I haven't tested this extensively but it seems to work for at least
basic tables with and without `<thead>`, `<tfoot>` and `<caption>`.

Fixes https://github.com/seanh/oatcake/issues/21
