### PR TITLE
Remove "Inline elements in figure captions"

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3351,32 +3351,6 @@ disagree with this mission.&lt;/p&gt;</code></pre>
           figure.
         </p>
 
-        <h3 class="notoc">
-          <b>Edge case:</b> inline elements in figure captions
-        </h3>
-
-        <p>All the inline elements work in figure captions:</p>
-
-        <figure>
-          <img
-            src="media/oats.jpg"
-            width="4815"
-            height="3265"
-            loading="lazy"
-            alt="A bowl of oats"
-            title="A bowl of oats"
-          />
-          <figcaption>
-            <strong>Laboris</strong> nisi ut aliquip ex ea commodo
-            <em>consequat</em>. <kbd>Ctrl</kbd> + <kbd>Alt</kbd> +
-            <kbd>Del</kbd> dolor in reprehenderit in voluptate velit
-            <code>esse cillum dolore</code> eu fugiat nulla pariatur.
-            <a href="https://example.com">Excepteur sint occaecat</a> cupidatat
-            <u>non proident</u>, <em>sunt in culpa</em> qui <del>officia</del>
-            <mark>deserunt mollit anim id est laborum.</mark>
-          </figcaption>
-        </figure>
-
         <h3 class="notoc"><b>Usage:</b> figure captions</h3>
         <p>
           Captions can be used for additional information about the figure


### PR DESCRIPTION
This example/test-case is no longer needed now that figure captions are
styled the same as normal text.
